### PR TITLE
Explicitly depend on newrelic_rpm gem

### DIFF
--- a/lib/partiarelic/app.rb
+++ b/lib/partiarelic/app.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'newrelic_rpm'
 
 module Partiarelic
   class App

--- a/partiarelic.gemspec
+++ b/partiarelic.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'newrelic_rpm'
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rack-test', '~> 0.6.3'
   spec.add_development_dependency 'pry-byebug', '~> 3.4'
-  spec.add_development_dependency 'newrelic_rpm'
 
   spec.add_dependency 'rack'
 end


### PR DESCRIPTION
Because we use the gem inside this gem.

@wata-gh Please take a look.