### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/lib/partiarelic/middleware.rb
+++ b/lib/partiarelic/middleware.rb
@@ -5,7 +5,7 @@ module Partiarelic
     def initialize(app, options={})
       @app = app
       @options = options
-      @partiarelic_app = App.new(options)
+      @partiarelic_app = App.new(**options)
     end
 
     ACCEPT_METHODS = %w[GET HEAD].freeze


### PR DESCRIPTION
Using `Partiarelic::Middleware` with Ruby 2.7 emits warnings along the lines of:

```
/path/to/partiarelic/lib/partiarelic/middleware.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/partiarelic/lib/partiarelic/app.rb:6: warning: The called method `initialize' is defined here
```

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/